### PR TITLE
fix: Quick fix for Apple Webkit modal height

### DIFF
--- a/src/app/views/map-viewer/tile-viewer/tile-viewer.component.scss
+++ b/src/app/views/map-viewer/tile-viewer/tile-viewer.component.scss
@@ -11,7 +11,7 @@
   scrollbar-color: var(--text-color) transparent;
 
   &-content {
-    height: 100%;
+    height: min-content;
     width: min-content;
     padding: .5rem;
     box-sizing: border-box;


### PR DESCRIPTION
This PR changes the `&-content` `height` rule in the `tile-viewer` component's CSS from `100%` to `min-content`, to ensure tile viewer modals on Apple Webkit (iOS, iPadOS, Safari) work as intended.

P.S.: I just kind of dived in to fix this so it could work on my iPad 😆 so it definitely could be cleaner or better tested! 